### PR TITLE
Increase version bounds of Cabal and base

### DIFF
--- a/cabal-test-quickcheck.cabal
+++ b/cabal-test-quickcheck.cabal
@@ -29,7 +29,7 @@ library
 
   build-depends:
     base       >= 4.6  && < 4.13,
-    Cabal      >= 1.16 && < 2.3,
+    Cabal      >= 1.16 && < 2.5,
     QuickCheck >= 2.8  && < 2.12
 
 source-repository head

--- a/cabal-test-quickcheck.cabal
+++ b/cabal-test-quickcheck.cabal
@@ -28,7 +28,7 @@ library
     Distribution.TestSuite.QuickCheck
 
   build-depends:
-    base       >= 4.6  && < 4.12,
+    base       >= 4.6  && < 4.13,
     Cabal      >= 1.16 && < 2.3,
     QuickCheck >= 2.8  && < 2.12
 


### PR DESCRIPTION
Bumps version numbers of cabal and base to support cabal 2.4 and 8.6.1.

Closes #7 and #8 .