### PR TITLE
Adds support for QuickCheck 2.12.*.

### DIFF
--- a/cabal-test-quickcheck.cabal
+++ b/cabal-test-quickcheck.cabal
@@ -30,7 +30,7 @@ library
   build-depends:
     base       >= 4.6  && < 4.12,
     Cabal      >= 1.16 && < 2.3,
-    QuickCheck >= 2.8  && < 2.12
+    QuickCheck >= 2.8  && < 2.13
 
 source-repository head
   type:     git

--- a/src/Distribution/TestSuite/QuickCheck.hs
+++ b/src/Distribution/TestSuite/QuickCheck.hs
@@ -127,7 +127,9 @@ toProgress result = Finished $ case result of
     GaveUp {}               -> Fail "Gave up"
     Failure { output }      -> Fail $ tidyFail output
     NoExpectedFailure {}    -> Fail "Expected failure when none occurred"
+#if !MIN_VERSION_QuickCheck(2, 12, 0)
     InsufficientCoverage {} -> Fail "Insufficient coverage in test"
+#endif
 
 tidyFail :: String -> String
 tidyFail output


### PR DESCRIPTION
- Bumps version boundary of QuickCheck in cabal file.
- Adds conditional check in Result handling due to case in datatype no
longer existing in QuickCheck 2.12.

Closes #9.