### PR TITLE
Allow building with GHC 8.8

### DIFF
--- a/cabal-test-quickcheck.cabal
+++ b/cabal-test-quickcheck.cabal
@@ -28,9 +28,9 @@ library
     Distribution.TestSuite.QuickCheck
 
   build-depends:
-    base       >= 4.6  && < 4.13,
-    Cabal      >= 1.16 && < 2.5,
-    QuickCheck >= 2.8  && < 2.13
+    base       >= 4.6  && < 4.14,
+    Cabal      >= 1.16 && < 3.1,
+    QuickCheck >= 2.8  && < 2.14
 
 source-repository head
   type:     git


### PR DESCRIPTION
This bumps the upper version bounds for `base`, `Cabal`, and `QuickCheck` to permit building with the versions necessary to use GHC 8.8.1.